### PR TITLE
Weight Regularization Implementation

### DIFF
--- a/models/__init__.py
+++ b/models/__init__.py
@@ -9,7 +9,7 @@ import os
 from . import classifier, gan, discrete_gan, featnet
 
 
-arch_names = ['gan', 'discrete_gan', 'classifier', 'featnet', 'minet', 'vral']
+arch_names = ['gan', 'discrete_gan', 'classifier','reg_classifier', 'featnet', 'minet', 'vral']
 logger = logging.getLogger('cortex.models')
 
 ARCHS = dict()

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -9,7 +9,7 @@ import os
 from . import classifier, gan, discrete_gan, featnet
 
 
-arch_names = ['gan', 'discrete_gan', 'classifier','reg_classifier', 'featnet', 'minet', 'vral']
+arch_names = ['gan', 'discrete_gan', 'classifier','reg_classifier', 'featnet', 'minet', 'vral', 'cae']
 logger = logging.getLogger('cortex.models')
 
 ARCHS = dict()

--- a/models/cae.py
+++ b/models/cae.py
@@ -1,0 +1,64 @@
+'''Contractive AutoEncoder model
+based partially on
+https://github.com/avijit9/Contractive_Autoencoder_in_Pytorch
+'''
+
+import logging
+
+import torch.nn as nn
+import torch.nn.functional as F
+
+from conv_decoders import SimpleConvDecoder as Decoder
+from convnets import SimpleConvEncoder as Encoder
+from .modules.regularization import Regularizer
+
+logger = logging.getLogger('cortex.models' + __name__)
+
+GLOBALS = {'DIM_X': None, 'DIM_Y': None, 'DIM_C': None, 'DIM_L': None}
+
+encoder_args_ = dict(dim_h=64, batch_norm=True, f_size=5, pad=2, stride=2,
+                     min_dim=7, nonlinearity='LeakyReLU', dim_out=10)
+decoder_args_ = dict(dim_h=64, batch_norm=True, f_size=5, pad=2, stride=1,
+                     dim_in=10)
+
+DEFAULTS = dict(
+    data=dict(batch_size=64,
+              test_batch_size=64),
+    optimizer=dict(
+        optimizer='Adam',
+        learning_rate=1e-4,
+    ),
+    model=dict(encoder_args=encoder_args_, decoder_args=decoder_args_),
+    procedures=dict(criterion=nn.L2Loss(), regularizer='cl'),
+    train=dict(
+        epochs=200,
+        summary_updates=100,
+        archive_every=10
+    )
+)
+
+
+def contractive_autoencoder(nets, inputs, criterion, regularizer=None,
+                            factor=0.0005):
+    X = inputs['images']
+    encoder = nets['encoder']
+    decoder = nets['decoder']
+    latent = encoder(X)
+    X_prime = decoder(latent, nonlinearity=F.tanh)
+    loss = criterion(X_prime, X)
+    reg_term = Regularizer(loss=criterion, reg_type=regularizer, factor=factor)
+    loss = reg_term.compute_reg_term(X_prime, X, X_prime, hidden_units=latent)
+    samples = dict(images=dict(generated=0.5 * (X_prime.data + 1.),
+                               real=0.5 * (X.data + 1.)))
+    return loss, dict(loss=loss.data[0]), samples, 'reconstruction'
+
+
+def build_model(encoder_args={}, decoder_args={}):
+    shape = (DIM_X, DIM_Y, DIM_C)
+
+    encoder = Encoder(shape, **encoder_args)
+    decoder = Decoder(shape, **decoder_args)
+    logger.debug(encoder)
+    logger.debug(decoder)
+
+    return dict(encoder=encoder, decoder=decoder), contractive_autoencoder

--- a/models/cae.py
+++ b/models/cae.py
@@ -5,31 +5,32 @@ https://github.com/avijit9/Contractive_Autoencoder_in_Pytorch
 
 import logging
 
+import torch
 import torch.nn as nn
 import torch.nn.functional as F
+from torch.autograd import Variable
 
-from conv_decoders import SimpleConvDecoder as Decoder
-from convnets import SimpleConvEncoder as Encoder
+from .modules.convnets import SimpleConvEncoder as Encoder
+from .modules.conv_decoders import SimpleConvDecoder as Decoder
 from .modules.regularization import Regularizer
+from .modules.modules import View
 
 logger = logging.getLogger('cortex.models' + __name__)
 
-GLOBALS = {'DIM_X': None, 'DIM_Y': None, 'DIM_C': None, 'DIM_L': None}
-
-encoder_args_ = dict(dim_h=64, batch_norm=True, f_size=5, pad=2, stride=2,
-                     min_dim=7, nonlinearity='LeakyReLU', dim_out=10)
-decoder_args_ = dict(dim_h=64, batch_norm=True, f_size=5, pad=2, stride=1,
-                     dim_in=10)
+encoder_args_ = dict(dim_h=64, batch_norm=True, n_steps=3, nonlinearity='ReLU')
+decoder_args_ = dict(dim_h=64, batch_norm=True, n_steps=3, dim_in=64)
+cae_args_ = dict(dim_h=784, n_steps=3, dim_latent=400)
 
 DEFAULTS = dict(
-    data=dict(batch_size=64,
-              test_batch_size=64),
+    data=dict(batch_size=dict(train=64, test=640)),
     optimizer=dict(
         optimizer='Adam',
         learning_rate=1e-4,
     ),
-    model=dict(encoder_args=encoder_args_, decoder_args=decoder_args_),
-    procedures=dict(criterion=nn.L2Loss(), regularizer='cl'),
+    model=dict(encoder_args=encoder_args_,
+               decoder_args=decoder_args_,
+               cae_args=cae_args_),
+    procedures=dict(criterion=F.mse_loss, regularizer='cl'),
     train=dict(
         epochs=200,
         summary_updates=100,
@@ -38,27 +39,79 @@ DEFAULTS = dict(
 )
 
 
-def contractive_autoencoder(nets, inputs, criterion, regularizer=None,
-                            factor=0.0005):
-    X = inputs['images']
-    encoder = nets['encoder']
-    decoder = nets['decoder']
-    latent = encoder(X)
-    X_prime = decoder(latent, nonlinearity=F.tanh)
-    loss = criterion(X_prime, X)
-    reg_term = Regularizer(loss=criterion, reg_type=regularizer, factor=factor)
-    loss = reg_term.compute_reg_term(X_prime, X, X_prime, hidden_units=latent)
-    samples = dict(images=dict(generated=0.5 * (X_prime.data + 1.),
-                               real=0.5 * (X.data + 1.)))
+class CAE(nn.Module):
+    def __init__(self, dim_h=64, dim_latent=64, n_steps=3):
+        super(CAE, self).__init__()
+        self.fc1 = nn.Linear(dim_h, dim_latent, bias=False)  # Encoder
+        self.fc2 = nn.Linear(dim_latent, dim_h, bias=False)  # Decoder
+        self.relu = nn.ReLU()
+        self.dim_latent = dim_latent
+        self.dim_h = dim_h
+        self.sigmoid = nn.Sigmoid()
+
+    def encoder(self, x):
+        h1 = self.relu(self.fc1(x.view(-1, self.dim_h)))
+        return h1
+
+    def decoder(self, z):
+        h2 = self.sigmoid(self.fc2(z))
+        return h2
+
+    def forward(self, x):
+            h1 = self.encoder(x)
+            self.latent = h1
+            h2 = self.decoder(h1)
+            return h1, h2
+
+
+mse_loss = nn.BCELoss(size_average = False)
+
+def loss_function(W, x, recons_x, h, lam):
+    """Compute the Contractive AutoEncoder Loss
+    Evalutes the CAE loss, which is composed as the summation of a Mean
+    Squared Error and the weighted l2-norm of the Jacobian of the hidden
+    units with respect to the inputs.
+    See reference below for an in-depth discussion:
+      #1: http://wiseodd.github.io/techblog/2016/12/05/contractive-autoencoder
+    Args:
+        `W` (FloatTensor): (N_hidden x N), where N_hidden and N are the
+          dimensions of the hidden units and input respectively.
+        `x` (Variable): the input to the network, with dims (N_batch x N)
+        recons_x (Variable): the reconstruction of the input, with dims
+          N_batch x N.
+        `h` (Variable): the hidden units of the network, with dims
+          batch_size x N_hidden
+        `lam` (float): the weight given to the jacobian regulariser term
+    Returns:
+        Variable: the (scalar) CAE loss
+    """
+    mse = mse_loss(recons_x, x)
+    # Since: W is shape of N_hidden x N. So, we do not need to transpose it as
+    # opposed to #1
+    dh = h * (1 - h) # Hadamard product produces size N_batch x N_hidden
+    # Sum through the input dimension to improve efficiency, as suggested in #1
+    w_sum = torch.sum(Variable(W)**2, dim=1)
+    # unsqueeze to avoid issues with torch.mv
+    w_sum = w_sum.unsqueeze(1) # shape N_hidden x 1
+    contractive_loss = torch.sum(torch.mm(dh**2, w_sum), 0)
+    return mse + contractive_loss.mul_(lam)
+
+
+def build_graph(net, inputs, criterion=None, regularizer=None, factor=1.0):
+    images = 0.5 * (inputs['images'] + 1.)
+    cae_net = net['cae']
+    hidden_representation, outputs = cae_net(images)
+    W = cae_net.state_dict()['fc1.weight']
+    loss = loss_function(W, images.view(-1, 784), outputs,
+                         hidden_representation, factor)
+    outputs=outputs.view(outputs.size(0), 28, 28)
+    samples = dict(images=dict(real=images),
+                   latents=dict(latent=cae_net.latent.data),
+                   labels=dict(latent=inputs['targets'].data))
     return loss, dict(loss=loss.data[0]), samples, 'reconstruction'
 
 
-def build_model(encoder_args={}, decoder_args={}):
-    shape = (DIM_X, DIM_Y, DIM_C)
-
-    encoder = Encoder(shape, **encoder_args)
-    decoder = Decoder(shape, **decoder_args)
-    logger.debug(encoder)
-    logger.debug(decoder)
-
-    return dict(encoder=encoder, decoder=decoder), contractive_autoencoder
+def build_model(data_handler, encoder_args={}, decoder_args={}, cae_args={}):
+    net = CAE(**cae_args)
+    shape = data_handler.get_dims('x', 'y', 'c')
+    return dict(cae=net), build_graph

--- a/models/modules/regularization.py
+++ b/models/modules/regularization.py
@@ -1,5 +1,5 @@
 '''
-Implements L1,  L2, Elastic-Net and Spectral Regularization
+Implements L1,  L2, Elastic-Net, Spectral Regularization, and Contractive Loss
 for various loss-types.
 
 TODO L1 with truncation
@@ -7,18 +7,50 @@ TODO L1 with truncation
 '''
 import torch
 import torch.nn as nn
+import numpy as np
+from torch.autograd import Variable
+
+
+def contractive_loss(parameters, hidden_u):
+    """Compute the Contractive AutoEncoder Loss
+        input  `W` (FloatTensor): (N_hidden x N), where N_hidden and N are the
+          dimensions of the hidden units and input respectively.
+
+        `h` (Variable): the hidden units of the network, with dims
+          batch_size x N_hidden\
+
+         based on
+         https://github.com/avijit9/Contractive_Autoencoder_in_Pytorch/
+    """
+    dh = hidden_u * (1 - hidden_u)  # Hadamard product
+    # Sum through the input dimension to improve efficiency, as suggested in #1
+    w_sum = torch.sum(Variable(parameters)**2, dim=1)
+    # unsqueeze to avoid issues with torch.mv
+    w_sum = w_sum.unsqueeze(1)  # shape N_hidden x 1
+    return torch.sum(torch.mm(dh**2, w_sum), 0)
 
 
 def spectral_norm(input):
     '''
         input : a pytorch tensor, for now, assuming real input
-        output : the spectral norm of the tensor, a functional
-        is currently broken for general tensors
+        output : the spectral norm of the tensor, taken by partitions
 
         TODO: fix for general tensors
     '''
-    x = input.view(input.numel())
-    return torch.sqrt(torch.max(torch.eig(torch.mul(torch.t(x), x))))
+    x = input
+    print(x.size())
+    if len(x.size()) == 4: # Then it's a convolutional layer
+        x = x.transpose(0, 1)
+        x = x.contiguous()
+        x = x.view(x.size(0), x.size(1)*x.size(2)*x.size(3))
+    elif len(x.size()) > 2:
+        x = x.view(x.size(0), np.prod(x.size()[1:]))
+    elif len(x.size()) == 1:
+        x = x.view(1, x.size(0)) 
+    ex = torch.eig(x.t()*x)
+    ex = ex[:][0]
+    print(torch.max(ex))
+    return torch.max(ex)
 
 
 def l1_norm(input):
@@ -49,12 +81,14 @@ class Regularizer():
     '''
         Class for performing regularization on parameters
     '''
-    REGULARIZERS = {'l1': l1_norm, 'l2':l2_norm, 'en':elastic_net, 'sp':spectral_norm}
+    REGULARIZERS = {'l1': l1_norm, 'l2': l2_norm, 'en': elastic_net,
+                    'sp': spectral_norm, 'cl': contractive_loss}
     regularizer = None
     factor = 0.0005
     loss = None
 
-    def __init__(self, reg_type='l1', factor=0.0005, loss=nn.CrossEntropyLoss()):
+    def __init__(self, reg_type='l1', factor=0.0005,
+                 loss=nn.CrossEntropyLoss()):
         '''
            reg_type - the kind of regularization
                   l1 - l1 regularization
@@ -63,16 +97,15 @@ class Regularizer():
                   sp - spectral regularization
 
           factor - the regularization hyper parameter
-          
           loss - the kind of loss to regularize
-
           methods: compute_reg_term - see docstring below
         '''
+        self.reg_type = reg_type
         self.regularizer = self.REGULARIZERS[reg_type]
-        self.factor=factor
+        self.factor = factor
         self.loss = loss
 
-    def compute_reg_term(self, input, target, parameters):
+    def compute_reg_term(self, input, target, parameters, hidden_units=None):
         '''
             computes the regularization term for given regularization
                 input: a torch tensor of inputs
@@ -80,7 +113,9 @@ class Regularizer():
                 parameters: the parameters to regularize
         '''
         total_loss = self.loss(input, target)
+        if self.reg_type == 'cl':
+            total_loss += self.factor*self.regularizer(parameters,
+                                                       hidden_units)
         for beta in parameters:
             total_loss += self.factor*self.regularizer(beta)
         return total_loss
-

--- a/models/modules/regularization.py
+++ b/models/modules/regularization.py
@@ -19,7 +19,7 @@ def spectral_norm(input):
    
 
 
-def reg_term(input, target, reg="l1", factor=0.0005, **kwargs):
+def reg_term(input, reg="l1", factor=0.0005, **kwargs):
     '''
         reg - computes standard regularization terms
         

--- a/models/modules/regularization.py
+++ b/models/modules/regularization.py
@@ -27,6 +27,8 @@ def contractive_loss(parameters, hidden_u):
     w_sum = torch.sum(Variable(parameters)**2, dim=1)
     # unsqueeze to avoid issues with torch.mv
     w_sum = w_sum.unsqueeze(1)  # shape N_hidden x 1
+    print(w_sum)
+    print(dh)
     return torch.sum(torch.mm(dh**2, w_sum), 0)
 
 

--- a/models/modules/regularization.py
+++ b/models/modules/regularization.py
@@ -1,0 +1,47 @@
+'''
+Implements L1,  L2, Elastic-Net and Spectral Regularization
+for various loss-types.
+
+TODO L1 with truncation
+
+'''
+import torch.nn as nn
+import torch.nn.functional as F
+import torch
+
+def spectral_norm(input):
+   '''
+       input : a pytorch tensor, for now, assuming real input
+
+       output : the spectral norm of the tensor
+   '''
+   return torch.sqrt(torch.max(torch.eig(torch.mul(torch.t(input), input))))
+   
+
+
+def reg_term(input, target, reg="l1", factor=0.0005, **kwargs):
+    '''
+        reg - computes standard regularization terms
+        
+        Args:
+            input: input tensor (N, *)
+            target: target tensor (N, *)
+
+        Output: scalar, if reduce is false
+
+        KWArgs:
+            reg: type of regularization: l1, l2, en, or spectral
+            factor: \lambda regularization hyper-parameter
+            kwargs: <see the nn.L1Loss docstring>
+    '''
+    reg = reg.lower()
+    reg_loss = 0
+    if reg == "l1" or reg == "en":
+        l1_loss = nn.L1Loss(**kwargs)
+        reg_loss += factor*l1_loss(input)
+    if reg == "l2" or reg == "en":
+        l2_loss = nn.MSELoss(**kwargs)
+        reg_loss += factor*l2_loss(input)
+    if reg == "spec":
+        reg_loss += factor*spectral_norm(input)
+    return reg_loss

--- a/models/modules/regularization.py
+++ b/models/modules/regularization.py
@@ -13,8 +13,12 @@ def spectral_norm(input):
     '''
         input : a pytorch tensor, for now, assuming real input
         output : the spectral norm of the tensor, a functional
+        is currently broken for general tensors
+
+        TODO: fix for general tensors
     '''
-    return torch.sqrt(torch.max(torch.eig(torch.mul(torch.t(input), input))))
+    x = input.view(input.numel())
+    return torch.sqrt(torch.max(torch.eig(torch.mul(torch.t(x), x))))
 
 
 def l1_norm(input):

--- a/models/modules/regularization.py
+++ b/models/modules/regularization.py
@@ -5,43 +5,78 @@ for various loss-types.
 TODO L1 with truncation
 
 '''
-import torch.nn as nn
-import torch.nn.functional as F
 import torch
+import torch.nn as nn
+
 
 def spectral_norm(input):
-   '''
-       input : a pytorch tensor, for now, assuming real input
-
-       output : the spectral norm of the tensor
-   '''
-   return torch.sqrt(torch.max(torch.eig(torch.mul(torch.t(input), input))))
-   
-
-
-def reg_term(input, reg="l1", factor=0.0005, **kwargs):
     '''
-        reg - computes standard regularization terms
-        
-        Args:
-            input: input tensor (N, *)
-            target: target tensor (N, *)
-
-        Output: scalar, if reduce is false
-
-        KWArgs:
-            reg: type of regularization: l1, l2, en, or spectral
-            factor: \lambda regularization hyper-parameter
-            kwargs: <see the nn.L1Loss docstring>
+        input : a pytorch tensor, for now, assuming real input
+        output : the spectral norm of the tensor, a functional
     '''
-    reg = reg.lower()
-    reg_loss = 0
-    if reg == "l1" or reg == "en":
-        l1_loss = nn.L1Loss(**kwargs)
-        reg_loss += factor*l1_loss(input)
-    if reg == "l2" or reg == "en":
-        l2_loss = nn.MSELoss(**kwargs)
-        reg_loss += factor*l2_loss(input)
-    if reg == "spec":
-        reg_loss += factor*spectral_norm(input)
-    return reg_loss
+    return torch.sqrt(torch.max(torch.eig(torch.mul(torch.t(input), input))))
+
+
+def l1_norm(input):
+        '''
+            input: a pytorch tensor
+            output: l1 norm functional
+        '''
+        return input.norm(1)
+
+
+def l2_norm(input):
+    '''
+        input: a pytorch tensor
+        output: l2 norm functional
+    '''
+    return input.norm(2)
+
+
+def elastic_net(input):
+    '''
+        input: a pytorch tensor
+        output: elastic net norm functional
+    '''
+    return l1_norm(input) + l2_norm(input)
+
+
+class Regularizer():
+    '''
+        Class for performing regularization on parameters
+    '''
+    REGULARIZERS = {'l1': l1_norm, 'l2':l2_norm, 'en':elastic_net, 'sp':spectral_norm}
+    regularizer = None
+    factor = 0.0005
+    loss = None
+
+    def __init__(self, reg_type='l1', factor=0.0005, loss=nn.CrossEntropyLoss()):
+        '''
+           reg_type - the kind of regularization
+                  l1 - l1 regularization
+                  l2 - l2 regularization
+                  en - elastic net regularization
+                  sp - spectral regularization
+
+          factor - the regularization hyper parameter
+          
+          loss - the kind of loss to regularize
+
+          methods: compute_reg_term - see docstring below
+        '''
+        self.regularizer = self.REGULARIZERS[reg_type]
+        self.factor=factor
+        self.loss = loss
+
+    def compute_reg_term(self, input, target, parameters):
+        '''
+            computes the regularization term for given regularization
+                input: a torch tensor of inputs
+                target: a torch tensor of targets
+                parameters: the parameters to regularize
+        '''
+        total_loss = self.loss(input, target)
+        for beta in parameters:
+            total_loss += self.factor*self.regularizer(beta)
+        return total_loss
+

--- a/models/reg_classifier.py
+++ b/models/reg_classifier.py
@@ -10,9 +10,11 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from .modules.convnets import SimpleConvEncoder as Net
-from .modules.regularization import reg_term
+from .modules.regularization import Regularizer
 
 logger = logging.getLogger('cortex.models' + __name__)
+
+regularizer_args_ = dict(reg_type='l1', factor=0.01)
 
 classifier_args_ = dict(dim_h=256, batch_norm=True, dropout=0.5, nonlinearity='ReLU',
                         f_size=4, stride=2, pad=1, min_dim=4)
@@ -24,32 +26,33 @@ DEFAULTS = dict(
         learning_rate=1e-4,
     ),
     model=dict(),
-    procedures=dict(criterion=nn.CrossEntropyLoss()),
+    procedures=dict(criterion=nn.CrossEntropyLoss(), regularizer='l1'),
     train=dict(
         epochs=200,
         summary_updates=100,
         archive_every=10
     )
+    
 )
 
 
-def classify(nets, inputs, criterion=None, regularizer=reg_term):
+def classify(nets, inputs, criterion=None, regularizer=None, factor=0.0005):
     net = nets['classifier']
     images = inputs['images']
     targets = inputs['targets']
+    reg_term = Regularizer(loss=criterion, reg_type=regularizer, factor=factor)
     outputs = net(images, nonlinearity=F.log_softmax)
-    loss = criterion(outputs, targets)
-    loss += regularizer(outputs)
+    loss = reg_term.compute_reg_term(outputs, targets, net.parameters())
     _, predicted = torch.max(outputs.data, 1)
     correct = 100. * predicted.eq(targets.data).cpu().sum() / targets.size(0)
     return loss, dict(loss=loss.data[0], accuracy=correct), None, 'accuracy'
 
 
-def build_model(data_handler, classifier_args=None):
+def build_model(data_handler, classifier_args=None, regularizer_args=None):
+    global REGULARIZER
     classifier_args = classifier_args or {}
     args = classifier_args_
     args.update(**classifier_args)
-
     shape = data_handler.get_dims('x', 'y', 'c')
     dim_l = data_handler.get_dims('labels')[0]
     net = Net(shape, dim_out=dim_l, **args)

--- a/models/reg_classifier.py
+++ b/models/reg_classifier.py
@@ -1,6 +1,12 @@
 '''
 Simple Regularized classifier model
 
+example usage:
+
+python main.py reg_classifier -S MNIST -n l1reg -a procedures.regularizer='l1'
+python main.py reg_classifier -S MNIST -n l1reg -a procedures.regularizer='l2'
+python main.py reg_classifier -S MNIST -n l1reg -a procedures.regularizer='en'
+
 '''
 
 import logging

--- a/models/reg_classifier.py
+++ b/models/reg_classifier.py
@@ -1,0 +1,56 @@
+'''
+Simple Regularized classifier model
+
+'''
+
+import logging
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+
+from .modules.convnets import SimpleConvEncoder as Net
+from .modules.regularization import reg_term
+
+logger = logging.getLogger('cortex.models' + __name__)
+
+classifier_args_ = dict(dim_h=256, batch_norm=True, dropout=0.5, nonlinearity='ReLU',
+                        f_size=4, stride=2, pad=1, min_dim=4)
+
+DEFAULTS = dict(
+    data=dict(batch_size=128),
+    optimizer=dict(
+        optimizer='Adam',
+        learning_rate=1e-4,
+    ),
+    model=dict(),
+    procedures=dict(criterion=nn.CrossEntropyLoss()),
+    train=dict(
+        epochs=200,
+        summary_updates=100,
+        archive_every=10
+    )
+)
+
+
+def classify(nets, inputs, criterion=None):
+    net = nets['classifier']
+    images = inputs['images']
+    targets = inputs['targets']
+    outputs = net(images, nonlinearity=F.log_softmax)
+    loss = criterion(outputs, targets)
+    loss += regularizer(outputs)
+    _, predicted = torch.max(outputs.data, 1)
+    correct = 100. * predicted.eq(targets.data).cpu().sum() / targets.size(0)
+    return loss, dict(loss=loss.data[0], accuracy=correct), None, 'accuracy'
+
+
+def build_model(data_handler, classifier_args=None):
+    classifier_args = classifier_args or {}
+    args = classifier_args_
+    args.update(**classifier_args)
+
+    shape = data_handler.get_dims('x', 'y', 'c')
+    dim_l = data_handler.get_dims('labels')[0]
+    net = Net(shape, dim_out=dim_l, **args)
+    return dict(classifier=net), classify

--- a/models/reg_classifier.py
+++ b/models/reg_classifier.py
@@ -4,8 +4,8 @@ Simple Regularized classifier model
 example usage:
 
 python main.py reg_classifier -S MNIST -n l1reg -a procedures.regularizer='l1'
-python main.py reg_classifier -S MNIST -n l1reg -a procedures.regularizer='l2'
-python main.py reg_classifier -S MNIST -n l1reg -a procedures.regularizer='en'
+python main.py reg_classifier -S MNIST -n l2reg -a procedures.regularizer='l2'
+python main.py reg_classifier -S MNIST -n enreg -a procedures.regularizer='en'
 
 '''
 

--- a/models/reg_classifier.py
+++ b/models/reg_classifier.py
@@ -33,7 +33,7 @@ DEFAULTS = dict(
 )
 
 
-def classify(nets, inputs, criterion=None):
+def classify(nets, inputs, criterion=None, regularizer=reg_term):
     net = nets['classifier']
     images = inputs['images']
     targets = inputs['targets']


### PR DESCRIPTION
Adds two new .py files:
"models/modules/regularization.py" - handles basic regularization tasks on weights using PyTorch

"models/reg_classifier.py" - a basic classifier with regularization, which defaults to L1 regularization, but can also perform L2 and EN via the command line. The regularization factor, lambda, can also be passed to the command line.

also adds the model registration to "models/__init__.py"

Usage:
python main.py reg_classifier -S MNIST -n l1reg -a procedures.regularizer='l1',procedures.factor=0.005
python main.py reg_classifier -S MNIST -n l2reg -a procedures.regularizer='l2',procedures.factor=0.005
python main.py reg_classifier -S MNIST -n enreg -a procedures.regularizer='en',procedures.factor=0.005

Notes:
L1, L2, and Elastic-Net regularization currently all work, and have been tested on MNIST data. Spectral regularization is not working for general tensors, and needs to be fixed, perhaps using the ideas discussed in Li et. al. 2016. 
