### PR TITLE
Remove 'inputs' -> 'images' rename

### DIFF
--- a/cortex/_lib/data/data_handler.py
+++ b/cortex/_lib/data/data_handler.py
@@ -128,9 +128,6 @@ class DataHandler:
             raise RuntimeError('Batch not set')
 
         item = self.inputs.get(item, item)
-        # TODO: Condition added for testing purpose.
-        if item == 'inputs':
-            item = 'images'
         if item not in self.batch.keys():
             raise KeyError('Data with label `{}` not found. Available: {}'
                            .format(item, tuple(self.batch.keys())))


### PR DESCRIPTION
This name shouldn't be so special.

Not sure if some other code relies on this.