### PR TITLE
fix errors when installing on windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,5 +24,5 @@ setup(name='cortex',
           'console_scripts': [
               'cortex=cortex.main:run']
       },
-      dependency_links={'git+https://github.com/facebookresearch/visdom.git'},
+      dependency_links=['git+https://github.com/facebookresearch/visdom.git'],
       zip_safe=False)


### PR DESCRIPTION
urls must be a list of string, not a dict